### PR TITLE
aslp-cpp: add verbose flag for printing loading dots, and set this flag in the test

### DIFF
--- a/aslp-client-http-cpp/include/aslp-cpp/aslp-cpp.hpp
+++ b/aslp-client-http-cpp/include/aslp-cpp/aslp-cpp.hpp
@@ -18,10 +18,11 @@ class aslp_connection
   using params_t = std::multimap<std::string, std::string>;
 
   const params_t& extra_params;
+  bool verbose;
   std::unique_ptr<httplib::Client> client {nullptr};
 
 public:
-  aslp_connection(const std::string& server_addr, int server_port, const params_t& extra_params = {});
+  aslp_connection(const std::string& server_addr, int server_port, const params_t& extra_params = {}, bool verbose = false);
   aslp_connection(aslp_connection&&) noexcept;
   auto get_opcode(uint32_t opcode) -> aslp_opcode_result_t;
   void wait_active();

--- a/aslp-client-http-cpp/source/aslp-cpp.cpp
+++ b/aslp-client-http-cpp/source/aslp-cpp.cpp
@@ -136,9 +136,20 @@ void aslp_connection::wait_active()
 {
   auto req = client->Get("/");
 
+  unsigned i = 0;
   while (req.error() != httplib::Error::Success) {
+    if (verbose) {
+      if (i == 0) {
+        std::cout << "Waiting for server to start.";
+      }
+      std::cout << "." << std::flush;
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     req = client->Get("/");
+    i++;
+  }
+  if (verbose && i != 0) {
+    std::cout << "\n";
   }
 }
 
@@ -172,8 +183,10 @@ aslp_opcode_result_t aslp_connection::get_opcode(uint32_t opcode)
 
 aslp_connection::aslp_connection(const std::string& server_addr,
                                  int server_port,
-                                 const params_t& extra_params) :
+                                 const params_t& extra_params,
+                                 bool verbose) :
   extra_params{extra_params},
+  verbose{verbose},
   client{std::make_unique<httplib::Client>(server_addr, server_port)}
 {}
 

--- a/aslp-client-http-cpp/test/source/aslp-cpp_test.cpp
+++ b/aslp-client-http-cpp/test/source/aslp-cpp_test.cpp
@@ -27,7 +27,8 @@ public:
 
 auto main() -> int
 {
-  auto s = aslp_connection("127.0.0.1", 8000);
+  auto s = aslp_connection("127.0.0.1", 8000, {}, true);
+  s.wait_active();
   auto gen = opgen();
 
   std::chrono::time_point begin = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION

in the tests, the printing all happens before timing begins.
previously, if you run the tests without an aslp-server,
it would appear to execute very quickly since errors are suppressed
and there is no other output.